### PR TITLE
qt5.1.0 is out. Unsure of the patch.

### DIFF
--- a/buildenv/osx/build-qt5.bash
+++ b/buildenv/osx/build-qt5.bash
@@ -1,13 +1,13 @@
 #!/bin/bash
-SHA1="7df93ca2cc5274f0cef72ea71f06feed2594b92f"
-curl -L -O "http://download.qt-project.org/official_releases/qt/5.0/5.0.2/single/qt-everywhere-opensource-src-5.0.2.tar.gz"
-if [ "$(shasum -a 1 qt-everywhere-opensource-src-5.0.2.tar.gz | cut -b -40)" != "${SHA1}" ]; then
-	echo qt5 checksum mismatch
-	exit
+SHA1="12d706124dbfac3d542dd3165176a978d478c085"
+curl -L -O "http://download.qt-project.org/official_releases/qt/5.1/5.1.0/single/qt-everywhere-opensource-src-5.1.0.tar.gz"
+if [ "$(shasum -a 1 qt-everywhere-opensource-src-5.1.0.tar.gz | cut -b -40)" != "${SHA1}" ]; then
+        echo qt5 checksum mismatch
+        exit
 fi
-tar -zxf qt-everywhere-opensource-src-5.0.2.tar.gz
-cd qt-everywhere-opensource-src-5.0.2
-patch -p1 < ../patches/qt5-QOpenGL2ExState.patch
+tar -zxf qt-everywhere-opensource-src-5.1.0.tar.gz
+cd qt-everywhere-opensource-src-5.1.0
+# patch -p1 < ../patches/qt5-QOpenGL2ExState.patch
 unset CFLAGS
 unset CXXFLAGS
 unset LDFLAGS


### PR DESCRIPTION
qt v5.0.x cannot be downloaded anymore. Here is an update to 5.1.0.

I am unsure about the patch that was in place. I cannot seem to find any instance of "QOpenGL2PaintEngineState" in "qtbase/src/opengl/gl2paintengineex/qpaintengineex_opengl2.cpp" so it is currently just commented out in case a new patch needs to be created.
