### PR TITLE
msi-strategy: update overlay helper names for 1.3.x.

### DIFF
--- a/msi-strategy/1.3.0-winx64-portable.strategy
+++ b/msi-strategy/1.3.0-winx64-portable.strategy
@@ -6,9 +6,9 @@
 mumble.exe
 mumble_app.dll
 mumble_ol.dll
-mumble_ol.exe
+mumble_ol_helper.exe
 mumble_ol_x64.dll
-mumble_ol_x64.exe
+mumble_ol_helper_x64.exe
 
 # Codecs
 celt0.0.11.0.dll

--- a/msi-strategy/1.3.0-winx64.strategy
+++ b/msi-strategy/1.3.0-winx64.strategy
@@ -6,9 +6,9 @@
 mumble.exe
 mumble_app.dll
 mumble_ol.dll
-mumble_ol.exe
+mumble_ol_helper.exe
 mumble_ol_x64.dll
-mumble_ol_x64.exe
+mumble_ol_helper_x64.exe
 murmur.exe
 
 # Codecs

--- a/msi-strategy/1.3.0.strategy
+++ b/msi-strategy/1.3.0.strategy
@@ -7,9 +7,9 @@ mumble.exe
 mumble_app.dll
 mumble_g15_helper.exe # was: mumble-g15-helper.exe
 mumble_ol.dll
-mumble_ol.exe
+mumble_ol_helper.exe
 mumble_ol_x64.dll
-mumble_ol_x64.exe
+mumble_ol_helper_x64.exe
 murmur.exe
 
 # Codecs


### PR DESCRIPTION
We recently changed their names to avoid a name clash
when generating PDB files.