### PR TITLE
Fix bug with fallback

### DIFF
--- a/buildenv/1.3.x/win32-static/setup/cygwin.cmd
+++ b/buildenv/1.3.x/win32-static/setup/cygwin.cmd
@@ -11,11 +11,13 @@
 
 :: First, try to query the registry for a potential Cygwin
 :: installation directory.
-for /f "tokens=2* delims= " %%a in ('reg query "HKCU\Software\Cygwin\Installations"') do set MUMBLE_CYGWIN_ROOT=%%b
-:: Clear the output of reg.exe.
-:: It write an error to stderr if it fails, and we seemingly
-:: cannot redirect it within a "for in" block.
-cls
+for /f "tokens=2* delims= " %%a in ('reg query "HKCU\Software\Cygwin\Installations" 2^>nul') do set MUMBLE_CYGWIN_ROOT=%%b
+
+:: HKCU\Software\Cygwin\Installations has a weird prefix on the install dir,
+:: so strip it if it's there.
+if "%MUMBLE_CYGWIN_ROOT:~0,4%" == "\??\" (
+	set MUMBLE_CYGWIN_ROOT=%MUMBLE_CYGWIN_ROOT:~4%
+)
 
 :: The registry query worked. Check if the directory actually
 :: exists. If it doesn't, unset MUMBLE_CYGWIN_ROOT such that
@@ -37,11 +39,6 @@ if not defined MUMBLE_CYGWIN_ROOT (
 	if exist "c:\cygwin64" (
 		set MUMBLE_CYGWIN_ROOT=c:\cygwin64
 	)
-)
-:: HKCU\Software\Cygwin\Installations has a weird prefix on the install dir,
-:: so strip it if it's there.
-if "%MUMBLE_CYGWIN_ROOT:~0,4%" == "\??\" (
-	set MUMBLE_CYGWIN_ROOT=%MUMBLE_CYGWIN_ROOT:~4%
 )
 
 for /f %%I in ('%MUMBLE_CYGWIN_ROOT%\bin\cygpath %MUMBLE_PREFIX%') do set BOOTSTRAP_CYGWIN_MUMBLE_PREFIX=%%I


### PR DESCRIPTION
We have to remove the `\??\` prefix right after (potentially) getting the value from the registry, otherwise the check whether the directory exists will choke on the prefix and unset `%MUMBLE_CYGWIN_ROOT%` regardless of whether the directory actually exists.

I also added a fix for the issue with redirecting the `reg query`'s error output to `nul`. That way the `cls` hack used previously is no longer required.