### PR TITLE
Use cygwin-bootstrap in buildenv/1.3.x/win32-static.

### DIFF
--- a/buildenv/1.3.x/win32-static/setup.cmd
+++ b/buildenv/1.3.x/win32-static/setup.cmd
@@ -111,6 +111,21 @@ set GIT_TARGET=%MUMBLE_PREFIX%\mumble-releng
 if exist %GIT_TARGET% ( rd /s /q %GIT_TARGET% )
 git clone --recursive "%MUMBLE_RELENG%" "%GIT_TARGET%" >NUL 2>NUL
 
+:: Setup Cygwin for the build environment.
+::
+:: If you want to use your own Cygwin, feel
+:: free to comment these lines out.
+powershell -ExecutionPolicy bypass -File setup\earlyfetch.ps1 "%MUMBLE_PREFIX_BUILD%\cygwin-bootstrap.exe" "https://github.com/mumble-voip/cygwin-bootstrap/releases/download/v0.2/cygwin-bootstrap.exe" "25be45e562fb2ca01898032c0bf4168a70705188e55c2956fc6171e677290268"
+if not "%errorlevel%"=="0" (
+	echo Unable to download cygwin-bootstrap
+	exit /b
+)
+"%MUMBLE_PREFIX_BUILD%\cygwin-bootstrap.exe" -target "%MUMBLE_PREFIX%\cygwin" -mirrors "https://s3.amazonaws.com/mumble-releng-distfiles/cygwin/2017-03-25-1953"
+if not "%errorlevel%"=="0" (
+	echo Unable bootstrap cygwin
+	exit /b
+)
+
 if not "%1"=="/noninteractive" (
 	echo.
 	echo Build environment successfully created.

--- a/buildenv/1.3.x/win32-static/setup/cygwin.cmd
+++ b/buildenv/1.3.x/win32-static/setup/cygwin.cmd
@@ -10,6 +10,14 @@
 @echo off
 
 set MUMBLE_CYGWIN_ROOT_SOURCE=environment
+
+:: First, check if we have a locally bootstrapped Cygwin
+:: in %MUMBLE_PREFIX%, and use it if available.
+if not defined MUMBLE_CYGWIN_ROOT (
+	set MUMBLE_CYGWIN_ROOT_SOURCE=buildenv
+	set MUMBLE_CYGWIN_ROOT=%MUMBLE_PREFIX%\cygwin
+)
+
 :: First, try to query the registry for a potential Cygwin
 :: installation directory.
 if not defined MUMBLE_CYGWIN_ROOT (

--- a/buildenv/1.3.x/win32-static/setup/cygwin.cmd
+++ b/buildenv/1.3.x/win32-static/setup/cygwin.cmd
@@ -66,6 +66,12 @@ if not defined MUMBLE_CYGWIN_ROOT (
 
 echo Using Cygwin from: %MUMBLE_CYGWIN_ROOT% (found in %MUMBLE_CYGWIN_ROOT_SOURCE%, set MUMBLE_CYGWIN_ROOT to choose another)
 
+:: Force Cygwin to resolve our (potential) %MUMBLE_PREFIX% junction point.
+:: This pre-seeds the knowledge that %MUMBLE_PREFIX% is a junction point before
+:: we start up Cygwin properly.
+for /f %%I in ('%MUMBLE_CYGWIN_ROOT%\bin\cygpath -u %MUMBLE_PREFIX%') do set MUMBLE_PREFIX_POSIXY=%%I
+%MUMBLE_CYGWIN_ROOT%\bin\mkdir -p %MUMBLE_PREFIX_POSIXY%/symfix >NUL 2>NUL
+%MUMBLE_CYGWIN_ROOT%\bin\rmdir %MUMBLE_PREFIX_POSIXY%/symfix >NUL 2>NUL
+
 for /f %%I in ('%MUMBLE_CYGWIN_ROOT%\bin\cygpath %MUMBLE_PREFIX%') do set BOOTSTRAP_CYGWIN_MUMBLE_PREFIX=%%I
 %MUMBLE_CYGWIN_ROOT%\bin\bash.exe -c "source /etc/profile && source ${BOOTSTRAP_CYGWIN_MUMBLE_PREFIX}/env && cd ${MUMBLE_PREFIX} && bash"
-

--- a/buildenv/1.3.x/win32-static/setup/earlyfetch.ps1
+++ b/buildenv/1.3.x/win32-static/setup/earlyfetch.ps1
@@ -1,0 +1,19 @@
+#!/usr/bin/env mumble-build
+# Copyright 2013-2017 The 'mumble-releng' Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that
+# can be found in the LICENSE file in the source tree or at
+# <http://mumble.info/mumble-releng/LICENSE>.
+
+$target = $Args[0]
+$url = $Args[1]
+$sha256hash = $Args[2]
+
+$client = New-Object System.Net.WebClient
+$client.DownloadFile($url, $target)
+$hash = Get-FileHash $target -Algorithm SHA256
+if (($hash.Hash) -ne ($sha256hash)) {
+	Remove-Item $target
+	exit 1
+}
+
+exit 0


### PR DESCRIPTION
This pull request updates the buildenv/1.3.x/win32-static buildenv to install its own copy of Cygwin, instead of relying on the user to do so.

Since we mirror the Cygwin installation files ourselves, this means that we now ensure that all users of a particular buildenv use the same Cygwin version -- which is great for ensuring stability and reproducibility of bugs.