### PR TITLE
Make using 1.3.x/win32-static/setup/prep.cmd easier to use in scripts

### DIFF
--- a/buildenv/1.3.x/win32-static/setup/mklinks.wsf
+++ b/buildenv/1.3.x/win32-static/setup/mklinks.wsf
@@ -34,7 +34,7 @@ lnk = shell.CreateShortcut(mumblePrefix + "\\MumbleBuild - cygwin.lnk");
 lnk.Description = "Launches a Mumble Build environment command prompt (cygwin bash)";
 lnk.IconLocation = "%WINDIR%\\system32\\cmd.exe";
 lnk.TargetPath = "%WINDIR%\\system32\\cmd.exe";
-lnk.Arguments = "/k prep.cmd cygwin.cmd";
+lnk.Arguments = "/k prep.cmd && cygwin.cmd";
 lnk.WindowStyle = 1;
 lnk.WorkingDirectory = mumblePrefix;
 lnk.Save();

--- a/buildenv/1.3.x/win32-static/setup/prep.cmd
+++ b/buildenv/1.3.x/win32-static/setup/prep.cmd
@@ -106,8 +106,7 @@ ECHO.
 ECHO Unknown version of Visual Studio detected. (VSVER is set to `%VSVER%`)
 ECHO Unable to initialize build environment. Aborting...
 ECHO.
-PAUSE
-EXIT
+EXIT /B 1
 
 :VS2010
 TITLE MumbleBuild MSVS2010 (v100)
@@ -227,5 +226,3 @@ SET PATH=%MUMBLE_JOM_PREFIX%\bin;%PATH%
 SET PATH=%MUMBLE_PROTOBUF_PREFIX%\vsprojects\%MUMBLE_BUILD_CONFIGURATION%;%PATH%
 if "%ARCH%" == "x86" SET PATH=%MUMBLE_ICE_PREFIX%\bin;%PATH%
 if "%ARCH%" == "amd64" SET PATH=%MUMBLE_ICE_PREFIX%\bin\x64;%PATH%
-cmd /V:ON /K %*
-exit /b


### PR DESCRIPTION
With this patch we no longer open a child cmd.exe a
script that wants to call prep.cmd would get stuck in.
It also removes a pause on error and instead exits with
an error code.