### PR TITLE
Make cygwin detection in 1.3.x/win32-static/setup/cygwin.cmd more robust

### DIFF
--- a/buildenv/1.3.x/win32-static/setup/cygwin.cmd
+++ b/buildenv/1.3.x/win32-static/setup/cygwin.cmd
@@ -9,9 +9,13 @@
 
 @echo off
 
+set MUMBLE_CYGWIN_ROOT_SOURCE=environment
 :: First, try to query the registry for a potential Cygwin
 :: installation directory.
-for /f "tokens=2* delims= " %%a in ('reg query "HKCU\Software\Cygwin\Installations" 2^>nul') do set MUMBLE_CYGWIN_ROOT=%%b
+if not defined MUMBLE_CYGWIN_ROOT (
+	for /f "tokens=2* delims= " %%a in ('reg query "HKCU\Software\Cygwin\Installations" 2^>nul') do set MUMBLE_CYGWIN_ROOT=%%b
+	set MUMBLE_CYGWIN_ROOT_SOURCE=registry
+)
 
 :: HKCU\Software\Cygwin\Installations has a weird prefix on the install dir,
 :: so strip it if it's there.
@@ -19,13 +23,17 @@ if "%MUMBLE_CYGWIN_ROOT:~0,4%" == "\??\" (
 	set MUMBLE_CYGWIN_ROOT=%MUMBLE_CYGWIN_ROOT:~4%
 )
 
-:: The registry query worked. Check if the directory actually
-:: exists. If it doesn't, unset MUMBLE_CYGWIN_ROOT such that
-:: the next check (the check below us) will fall back to
-:: using standard Cygwin directories.
+:: The registry query worked. However, the directory we found might not be a real
+:: Cygwin installation. It might just be an SDK (such as the Android SDK), or something
+:: else that uses a cygwin1.dll. To determine if it is a proper Cygwin installation, we
+:: check if /bin/bash.exe exists. If it doesn't, unset MUMBLE_CYGWIN_ROOT such
+:: that the next check (the check below us) will fall back to using standard Cygwin
+:: directories.
 if defined MUMBLE_CYGWIN_ROOT (
-	if not exist "%MUMBLE_CYGWIN_ROOT%" (
+	if not exist "%MUMBLE_CYGWIN_ROOT%\bin\bash.exe" (
+		echo Discarding %MUMBLE_CYGWIN_ROOT_SOURCE% Cygwin root candidate from %MUMBLE_CYGWIN_ROOT%, bin\bash.exe not found.
 		set MUMBLE_CYGWIN_ROOT=
+		set MUMBLE_CYGWIN_ROOT_SOURCE=defaults
 	)
 )
 
@@ -41,5 +49,15 @@ if not defined MUMBLE_CYGWIN_ROOT (
 	)
 )
 
+:: If we still do not have a usable root, bail.
+if not defined MUMBLE_CYGWIN_ROOT (
+	echo Failed to find a usable Cygwin root. Please make sure you have a Cygwin installed.
+	echo You can set MUMBLE_CYGWIN_ROOT to select a specific Cygwin.
+	exit /b 1
+)
+
+echo Using Cygwin from: %MUMBLE_CYGWIN_ROOT% (found in %MUMBLE_CYGWIN_ROOT_SOURCE%, set MUMBLE_CYGWIN_ROOT to choose another)
+
 for /f %%I in ('%MUMBLE_CYGWIN_ROOT%\bin\cygpath %MUMBLE_PREFIX%') do set BOOTSTRAP_CYGWIN_MUMBLE_PREFIX=%%I
 %MUMBLE_CYGWIN_ROOT%\bin\bash.exe -c "source /etc/profile && source ${BOOTSTRAP_CYGWIN_MUMBLE_PREFIX}/env && cd ${MUMBLE_PREFIX} && bash"
+


### PR DESCRIPTION
* Make sure we do not overwrite MUMBLE_CYGWIN_ROOT if we get
  it from the environment.
* Improve check on whether we found a valid cygwin by looking
  for bash. That way we don't pick up stray cygwin1.dll files
  from the registry.
* Add some output so you have a chance of diagnosing what is
  wrong.