### PR TITLE
Fix error handling pattern in *.cmd

### DIFF
--- a/buildscripts/1.2.x/buildenv-win32.cmd
+++ b/buildscripts/1.2.x/buildenv-win32.cmd
@@ -48,4 +48,4 @@ cd ..\..\..
 
 for /f "delims=" %%I in ('%MUMBLE_CYGWIN_ROOT%\bin\cygpath.exe -u "%cd%"') do set PWD_CYGWIN=%%I
 cmd /c %BUILDENV_DIR%\prep.cmd %MUMBLE_CYGWIN_ROOT%\bin\bash.exe -c "source /etc/profile && cd \"%PWD_CYGWIN%\" && bash -ex buildscripts/1.2.x/buildenv-win32.bash"
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%

--- a/buildscripts/1.2.x/mumble-win32.cmd
+++ b/buildscripts/1.2.x/mumble-win32.cmd
@@ -10,7 +10,7 @@ IF NOT DEFINED MUMBLE_BUILDENV_DIR (SET MUMBLE_BUILDENV_DIR=%%M)
 for /F %%G IN ('%MUMBLE_BUILDENV_DIR%\mumble-releng\tools\mumble-version.py') DO SET mumblebuildversion=%%G
 
 call %MUMBLE_BUILDENV_DIR%\prep.cmd
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 echo Build mumble
 if "%MUMBLE_BUILD_TYPE%" == "Release" (
@@ -18,32 +18,32 @@ if "%MUMBLE_BUILD_TYPE%" == "Release" (
 ) else (
 	qmake CONFIG-=sse2 CONFIG+=packaged DEFINES+="MUMBLE_VERSION=%mumblebuildversion% SNAPSHOT_BUILD=1" -recursive
 )
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 nmake release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 echo Build SSE2 versions of opus
 cd opus-build
 qmake -recursive
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 nmake release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..
 
 echo Build SSE2 versions of celt 0.11.0
 cd celt-0.11.0-build
 qmake -recursive
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 nmake release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..
 
 echo Build SSE2 versions of celt 0.7.0
 cd celt-0.7.0-build
 qmake -recursive
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 nmake release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..
 
 if "%MUMBLE_DO_PLUGIN_REPLACEMENT" == "1" (
@@ -64,17 +64,17 @@ SET MumbleZlibDir=%MUMBLE_PREFIX%\zlib\lib
 SET MumbleBzip2Dir=%MUMBLE_PREFIX%\bzip2\lib
 cd scripts
 call mkini-win32.bat
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..\installer
 c:\cygwin\bin\sed -ri "s,</Include>,<?define RedistDirVC10 = \"C:\\\\Program Files (x86)\\\\Microsoft Visual Studio 10.0\\\\VC\\\\redist\\\\x86\\\\Microsoft.VC100.CRT\" ?></Include>,g" Settings.wxi
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 msbuild  /p:Configuration=Release MumbleInstall.sln /t:Clean,Build
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 perl build_installer.pl
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd bin\Release
 rename Mumble.msi "mumble-%mumblebuildversion%.msi"
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..\..\..
 
 if not "%MUMBLE_SKIP_INTERNAL_SIGNING%" == "1" (
@@ -83,4 +83,4 @@ if not "%MUMBLE_SKIP_INTERNAL_SIGNING%" == "1" (
 )
 
 "%MUMBLE_BUILDENV_DIR%\mumble-releng\tools\collect_symbols.py" collect --version "%mumblebuildversion%" --buildtype "%MUMBLE_BUILD_TYPE%" --product "Mumble %MUMBLE_BUILD_ARCH%" release\ symbols.7z
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%

--- a/buildscripts/1.3.x/buildenv-win32-static.cmd
+++ b/buildscripts/1.3.x/buildenv-win32-static.cmd
@@ -48,4 +48,4 @@ cd ..\..\..
 
 for /f "delims=" %%I in ('%MUMBLE_CYGWIN_ROOT%\bin\cygpath.exe -u "%cd%"') do set PWD_CYGWIN=%%I
 cmd /c %BUILDENV_DIR%\prep.cmd %MUMBLE_CYGWIN_ROOT%\bin\bash.exe -c "source /etc/profile && cd \"%PWD_CYGWIN%\" && bash -ex buildscripts/1.3.x/buildenv-win32-static.bash"
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%

--- a/buildscripts/1.3.x/buildenv-win64-static.cmd
+++ b/buildscripts/1.3.x/buildenv-win64-static.cmd
@@ -48,4 +48,4 @@ cd ..\..\..
 
 for /f "delims=" %%I in ('%MUMBLE_CYGWIN_ROOT%\bin\cygpath.exe -u "%cd%"') do set PWD_CYGWIN=%%I
 cmd /c %BUILDENV_DIR%\prep.cmd %MUMBLE_CYGWIN_ROOT%\bin\bash.exe -c "source /etc/profile && cd \"%PWD_CYGWIN%\" && bash -ex buildscripts/1.3.x/buildenv-win64-static.bash"
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%

--- a/buildscripts/1.3.x/mumble-win32-static.cmd
+++ b/buildscripts/1.3.x/mumble-win32-static.cmd
@@ -12,7 +12,7 @@ IF NOT DEFINED MUMBLE_NMAKE (SET MUMBLE_NMAKE=nmake)
 for /F %%G IN ('python %MUMBLE_BUILDENV_DIR%\mumble-releng\tools\mumble-version.py') DO SET mumblebuildversion=%%G
 
 call %MUMBLE_BUILDENV_DIR%\prep.cmd
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 :: Prep switches echo off, reenable it
 @echo on
@@ -23,38 +23,38 @@ if "%MUMBLE_BUILD_TYPE%" == "Release" (
 ) else (
 	qmake CONFIG+="release static symbols packaged %MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS%" DEFINES+="MUMBLE_VERSION=%mumblebuildversion% SNAPSHOT_BUILD=1" -recursive
 )
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 %MUMBLE_NMAKE% release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 echo Build SSE2 versions of opus
 cd 3rdparty\opus-build
 %MUMBLE_NMAKE% clean
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 qmake -recursive CONFIG+=sse2
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 %MUMBLE_NMAKE% release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..\..
 
 echo Build SSE2 versions of celt 0.11.0
 cd 3rdparty\celt-0.11.0-build
 %MUMBLE_NMAKE% clean
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 %MUMBLE_NMAKE% -recursive CONFIG+=sse2
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 %MUMBLE_NMAKE% release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..\..
 
 echo Build SSE2 versions of celt 0.7.0
 cd 3rdparty\celt-0.7.0-build
 %MUMBLE_NMAKE% clean
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 qmake -recursive CONFIG+=sse2
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 %MUMBLE_NMAKE% release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..\..
 
 if "%MUMBLE_DO_PLUGIN_REPLACEMENT" == "1" (
@@ -69,27 +69,27 @@ SET MumbleSourceDir=%cd%
 SET MumbleVersionSubDir=%mumblebuildversion%
 cd scripts
 call mkini-win32.bat
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..\installer
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 msbuild  /p:Configuration=Release;Platform=x86 MumbleInstall.sln /t:Clean,Build
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 perl build_installer.pl
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd bin\Release
 rename Mumble.msi "mumble-%mumblebuildversion%.msi"
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 cd ..\..\..
 
 if not "%MUMBLE_SKIP_INTERNAL_SIGNING%" == "1" (
 	echo Adding build machine's signature to installer
 	signtool sign /sm /a "installer/bin/Release/mumble-%mumblebuildversion%.msi"
-	if errorlevel 1 exit /b errorlevel
+	if errorlevel 1 exit /b %errorlevel%
 )
 
 if not "%MUMBLE_SKIP_COLLECT_SYMBOLS%" == "1" (
 	python "%MUMBLE_BUILDENV_DIR%\mumble-releng\tools\collect_symbols.py" collect --version "%mumblebuildversion%" --buildtype "%MUMBLE_BUILD_TYPE%" --product "Mumble %MUMBLE_BUILD_ARCH%" release\ symbols.7z
-	if errorlevel 1 exit /b errorlevel
+	if errorlevel 1 exit /b %errorlevel%
 )
 

--- a/buildscripts/1.3.x/mumble-win64-static-portable.cmd
+++ b/buildscripts/1.3.x/mumble-win64-static-portable.cmd
@@ -11,7 +11,7 @@ IF NOT DEFINED MUMBLE_NMAKE (SET MUMBLE_NMAKE=nmake)
 for /F %%G IN ('python %MUMBLE_BUILDENV_DIR%\mumble-releng\tools\mumble-version.py') DO SET mumblebuildversion=%%G
 
 call %MUMBLE_BUILDENV_DIR%\prep.cmd
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 :: Prep switches echo off, reenable it
 @echo on
@@ -22,35 +22,35 @@ if "%MUMBLE_BUILD_TYPE%" == "Release" (
 ) else (
 	qmake CONFIG+="release static symbols packaged no-g15 no-asio no-elevation no-server %MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS%" DEFINES+="MUMBLE_VERSION=%mumblebuildversion% SNAPSHOT_BUILD=1" -recursive
 )
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 %MUMBLE_NMAKE% release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 set zipdir=mumble-%mumblebuildversion%.portable.winx64
 set zipfile=%zipdir%.zip
 mkdir mumble-%mumblebuildversion%.portable.winx64
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 copy release\*.exe %zipdir%\
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 copy release\*.dll %zipdir%\
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 mkdir %zipdir%\plugins
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 copy release\plugins\*.dll %zipdir%\plugins\
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 copy "C:\Program Files (x86)\Windows Kits\8.1\Redist\D3D\x64\d3dcompiler_47.dll" %zipdir%\
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 copy "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\redist\x64\Microsoft.VC120.CRT\msvcp120.dll" %zipdir%\
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 copy "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\redist\x64\Microsoft.VC120.CRT\msvcr120.dll" %zipdir%\
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 "C:\Program Files\7-Zip\7z.exe" a %zipfile% %zipdir%
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 if not "%MUMBLE_SKIP_COLLECT_SYMBOLS%" == "1" (
 	python "%MUMBLE_BUILDENV_DIR%\mumble-releng\tools\collect_symbols.py" collect --version "%mumblebuildversion%" --buildtype "%MUMBLE_BUILD_TYPE%" --product "Mumble %MUMBLE_BUILD_ARCH% Portable" release\ symbols.7z
-	if errorlevel 1 exit /b errorlevel
+	if errorlevel 1 exit /b %errorlevel%
 )

--- a/buildscripts/1.3.x/mumble-win64-static.cmd
+++ b/buildscripts/1.3.x/mumble-win64-static.cmd
@@ -12,7 +12,7 @@ IF NOT DEFINED MUMBLE_NMAKE (SET MUMBLE_NMAKE=nmake)
 for /F %%G IN ('python %MUMBLE_BUILDENV_DIR%\mumble-releng\tools\mumble-version.py') DO SET mumblebuildversion=%%G
 
 call %MUMBLE_BUILDENV_DIR%\prep.cmd
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 :: Prep switches echo off, reenable it
 @echo on
@@ -23,9 +23,9 @@ if "%MUMBLE_BUILD_TYPE%" == "Release" (
 ) else (
 	qmake CONFIG+="release static symbols packaged %MUMBLE_EXTRA_QMAKE_CONFIG_FLAGS%" DEFINES+="MUMBLE_VERSION=%mumblebuildversion% SNAPSHOT_BUILD=1" -recursive
 )
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 %MUMBLE_NMAKE% release
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 echo Build installer
 SET MumbleNoMergeModule=1
@@ -35,27 +35,27 @@ SET MumbleSourceDir=%cd%
 SET MumbleVersionSubDir=%mumblebuildversion%
 cd scripts
 call mkini-win32.bat
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd ..\installer
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 msbuild  /p:Configuration=Release;Platform=x64 MumbleInstall.sln /t:Clean,Build
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 perl build_installer.pl
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 cd bin\x64\Release
 rename Mumble.msi "mumble-%mumblebuildversion%.winx64.msi"
-if errorlevel 1 exit /b errorlevel
+if errorlevel 1 exit /b %errorlevel%
 
 cd ..\..\..\..
 
 if not "%MUMBLE_SKIP_INTERNAL_SIGNING%" == "1" (
 	echo Adding build machine's signature to installer
 	signtool sign /sm /a "installer/bin/x64/Release/mumble-%mumblebuildversion%.winx64.msi"
-	if errorlevel 1 exit /b errorlevel
+	if errorlevel 1 exit /b %errorlevel%
 )
 
 if not "%MUMBLE_SKIP_COLLECT_SYMBOLS%" == "1" (
 	python "%MUMBLE_BUILDENV_DIR%\mumble-releng\tools\collect_symbols.py" collect --version "%mumblebuildversion%" --buildtype "%MUMBLE_BUILD_TYPE%" --product "Mumble %MUMBLE_BUILD_ARCH%" release\ symbols.7z
-	if errorlevel 1 exit /b errorlevel
+	if errorlevel 1 exit /b %errorlevel%
 )
 


### PR DESCRIPTION
Replace "if errorlevel 1 exit /b errorlevel" with
"if errorlevel 1 exit /b %ERRORLEVEL%". The latter
properly transports the errorlevel to outside callers
like powershell while the latter only seems to
work when the script is called from cmd.exe