### PR TITLE
Properly return error codes for errors in ifs in mumble-win*.cmd

### DIFF
--- a/buildscripts/1.3.x/mumble-win32-static.cmd
+++ b/buildscripts/1.3.x/mumble-win32-static.cmd
@@ -61,6 +61,7 @@ if "%MUMBLE_DO_PLUGIN_REPLACEMENT" == "1" (
 	echo Perform plugin replacement
 	python "%MUMBLE_PREFIX%\mumble-releng\tools\plugin_replacement.py" --version "%mumblebuildversion%" --repo . release\plugins
 )
+if errorlevel 1 exit /b %errorlevel%
 
 echo Build installer
 SET MumbleNoMergeModule=1
@@ -85,11 +86,10 @@ cd ..\..\..
 if not "%MUMBLE_SKIP_INTERNAL_SIGNING%" == "1" (
 	echo Adding build machine's signature to installer
 	signtool sign /sm /a "installer/bin/Release/mumble-%mumblebuildversion%.msi"
-	if errorlevel 1 exit /b %errorlevel%
 )
+if errorlevel 1 exit /b %errorlevel%
 
 if not "%MUMBLE_SKIP_COLLECT_SYMBOLS%" == "1" (
 	python "%MUMBLE_BUILDENV_DIR%\mumble-releng\tools\collect_symbols.py" collect --version "%mumblebuildversion%" --buildtype "%MUMBLE_BUILD_TYPE%" --product "Mumble %MUMBLE_BUILD_ARCH%" release\ symbols.7z
-	if errorlevel 1 exit /b %errorlevel%
 )
-
+if errorlevel 1 exit /b %errorlevel%

--- a/buildscripts/1.3.x/mumble-win64-static-portable.cmd
+++ b/buildscripts/1.3.x/mumble-win64-static-portable.cmd
@@ -52,5 +52,5 @@ if errorlevel 1 exit /b %errorlevel%
 
 if not "%MUMBLE_SKIP_COLLECT_SYMBOLS%" == "1" (
 	python "%MUMBLE_BUILDENV_DIR%\mumble-releng\tools\collect_symbols.py" collect --version "%mumblebuildversion%" --buildtype "%MUMBLE_BUILD_TYPE%" --product "Mumble %MUMBLE_BUILD_ARCH% Portable" release\ symbols.7z
-	if errorlevel 1 exit /b %errorlevel%
 )
+if errorlevel 1 exit /b %errorlevel%

--- a/buildscripts/1.3.x/mumble-win64-static.cmd
+++ b/buildscripts/1.3.x/mumble-win64-static.cmd
@@ -51,11 +51,10 @@ cd ..\..\..\..
 if not "%MUMBLE_SKIP_INTERNAL_SIGNING%" == "1" (
 	echo Adding build machine's signature to installer
 	signtool sign /sm /a "installer/bin/x64/Release/mumble-%mumblebuildversion%.winx64.msi"
-	if errorlevel 1 exit /b %errorlevel%
 )
+if errorlevel 1 exit /b %errorlevel%
 
 if not "%MUMBLE_SKIP_COLLECT_SYMBOLS%" == "1" (
 	python "%MUMBLE_BUILDENV_DIR%\mumble-releng\tools\collect_symbols.py" collect --version "%mumblebuildversion%" --buildtype "%MUMBLE_BUILD_TYPE%" --product "Mumble %MUMBLE_BUILD_ARCH%" release\ symbols.7z
-	if errorlevel 1 exit /b %errorlevel%
 )
-
+if errorlevel 1 exit /b %errorlevel%


### PR DESCRIPTION
Turns out everything in a if "branch" gets expanded by cmd as soon as the
branch is entered. This means that if errorlevel gets changed in during the
branch because our conditional command failed the following exit call already
had its error code expanded to 0. We can work around this by either using
delayed expansion on the errorlevel in these branches or by checking for errors
after the branches. This patch implements the latter variant. Mostly because we
can (as soon as we have to calls in the branch delayed expansion would be the
only way to go) and because it the impact is smaller at this point. Might switch
over later.