### PR TITLE
Do not compile Ice CPP tests

### DIFF
--- a/buildenv/1.3.x/win32-static/patches/zeroc-ice-3.6.3-skip-cpp-test-build.patch
+++ b/buildenv/1.3.x/win32-static/patches/zeroc-ice-3.6.3-skip-cpp-test-build.patch
@@ -1,0 +1,20 @@
+--- ./cpp/Makefile.mak
++++ ./cpp/Makefile.mak
+@@ -15,7 +15,7 @@
+ 
+ !if "$(WINRT)" != "yes"
+ 
+-SUBDIRS		= config src include test 
++SUBDIRS		= config src include
+ 
+ install:: install-common
+ 	@for %i in ( $(INSTALL_SUBDIRS) ) do \
+@@ -32,7 +32,7 @@
+ 
+ !else
+ 
+-SUBDIRS		= src include test
++SUBDIRS		= src include
+ 
+ INSTALL_SUBDIRS	= $(INSTALL_SUBDIRS) $(prefix)\SDKs
+ 

--- a/buildenv/1.3.x/win32-static/zeroc-ice.build
+++ b/buildenv/1.3.x/win32-static/zeroc-ice.build
@@ -33,6 +33,7 @@ function prepare {
 	patch -p1 < ${MUMBLE_BUILDENV_ROOT}/patches/zeroc-ice-3.6.1-user-configurable-win32-winnt.patch
 	patch -p1 < ${MUMBLE_BUILDENV_ROOT}/patches/zeroc-ice-3.6.1-wc-err-invalid-chars-xp-fix.patch
 	patch -p1 < ${MUMBLE_BUILDENV_ROOT}/patches/zeroc-ice-3.6.1-allow-schannel-engine-to-build-against-xp-and-vista-win32-winnt.patch
+	patch -p1 < ${MUMBLE_BUILDENV_ROOT}/patches/zeroc-ice-3.6.3-skip-cpp-test-build.patch
 }
 
 function build {


### PR DESCRIPTION
The Ice CPP tests folder is 8 GB big once compiled.

We do not run the tests, so the compile time and disk space this test
compilation uses is a huge unnecessary factor.

We reduce our compiled Ice build folder from ~12 GB to ~3 GB.

---

Fixes #59