### PR TITLE
buildenv/1.2.x/win32: add protobuf patch to fix MapDirectory test failure.

### DIFF
--- a/buildenv/1.2.x/win32/patches/protobuf-2.6.1-remove-openfile-slash-suffix.patch
+++ b/buildenv/1.2.x/win32/patches/protobuf-2.6.1-remove-openfile-slash-suffix.patch
@@ -1,0 +1,20 @@
+It turns out that Windows is inconsistent about opening
+files ending in slashes.
+
+In some situations, it will allow it, in others, it won't.
+
+In previous bugs, it seemed to only reproduce when inside
+a junction point. But now it seems more widespread: for example,
+a simple Python program trying to open() a file with a trailing
+slash works on the root of my D: drive, but not on my C: drive.
+
+--- ./src/google/protobuf/compiler/importer_unittest.cc
++++ ./src/google/protobuf/compiler/importer_unittset.cc
+@@ -422,7 +422,6 @@ TEST_F(DiskSourceTreeTest, MapDirectory)
+   ExpectCannotOpenFile("baz/./foo",
+                        "Backslashes, consecutive slashes, \".\", or \"..\" are "
+                        "not allowed in the virtual path");
+-  ExpectCannotOpenFile("baz/foo/", "File not found.");
+ }
+ 
+ TEST_F(DiskSourceTreeTest, NoParent) {

--- a/buildenv/1.2.x/win32/protobuf.build
+++ b/buildenv/1.2.x/win32/protobuf.build
@@ -22,6 +22,7 @@ function extract {
 function prepare {
 	patch -p1 < ${MUMBLE_BUILDENV_ROOT}/patches/protobuf-2.5.0-fix-missing-algorithm-h-msvs2013.patch
 	patch -p1 < ${MUMBLE_BUILDENV_ROOT}/patches/protobuf-2.5.0-win32-disable-OutputDirectoryIsFileError-test.patch
+	patch -p1 < ${MUMBLE_BUILDENV_ROOT}/patches/protobuf-2.6.1-remove-openfile-slash-suffix.patch
 
 	cd vsprojects
 


### PR DESCRIPTION
We've seen odd behavior from Windows when trying to open files that end in
trailing slashes.

Sometimes, Windows ignores trailing slashes in filenames.

I.e., if thre's a file

   C:\asdf\foo

Windows sometimes allows you to open it as "asdf\\foo\\".
Sometimes it doesn't.

For me, it works on my C: drive, but not my D: drive.

We've previously speculated that this was due to junction points,
but since the root of my D: drive behaves the same, I don't think
that's the culprit.

For now, let's just apply this patch such that protobuf doesn't
expect opening files with a trailing slash to always fail.

Fixes mumble-voip/mumble-releng#65
Updates mumble-voip/mumble-releng#44
Updates mumble-voip/mumble-releng#5