### PR TITLE
buildenv/1.2.x: use i686-w64-mingw32 triple instead of i686-pc-mingw32.

### DIFF
--- a/buildenv/1.2.x/win32/libflac.build
+++ b/buildenv/1.2.x/win32/libflac.build
@@ -20,7 +20,7 @@ function extract {
 }
 
 function build {
-	./configure --host=i686-pc-mingw32 --prefix=${MUMBLE_SNDFILE_PREFIX} --disable-shared --enable-static --with-pic
+	./configure --host=i686-w64-mingw32 --prefix=${MUMBLE_SNDFILE_PREFIX} --disable-shared --enable-static --with-pic
 	make
 }
 

--- a/buildenv/1.2.x/win32/libogg.build
+++ b/buildenv/1.2.x/win32/libogg.build
@@ -20,7 +20,7 @@ function extract {
 }
 
 function build {
-	./configure --host=i686-pc-mingw32 --prefix=${MUMBLE_SNDFILE_PREFIX} --disable-shared --enable-static --with-pic
+	./configure --host=i686-w64-mingw32 --prefix=${MUMBLE_SNDFILE_PREFIX} --disable-shared --enable-static --with-pic
 	make
 }
 

--- a/buildenv/1.2.x/win32/libsndfile.build
+++ b/buildenv/1.2.x/win32/libsndfile.build
@@ -28,7 +28,7 @@ function prepare {
 }
 
 function build {
-	./configure --host=i686-pc-mingw32 --prefix=${MUMBLE_SNDFILE_PREFIX} --enable-shared --with-pic --disable-sqlite
+	./configure --host=i686-w64-mingw32 --prefix=${MUMBLE_SNDFILE_PREFIX} --enable-shared --with-pic --disable-sqlite
 	make LDFLAGS="-Wl,-lFLAC -Wl,-lvorbisenc -Wl,-lvorbis -Wl,-lvorbisfile, -Wl,-logg"
 
 	cd src/.libs

--- a/buildenv/1.2.x/win32/libvorbis.build
+++ b/buildenv/1.2.x/win32/libvorbis.build
@@ -20,7 +20,7 @@ function extract {
 }
 
 function build {
-	./configure --host=i686-pc-mingw32 --prefix=${MUMBLE_SNDFILE_PREFIX} --disable-shared --enable-static --with-pic
+	./configure --host=i686-w64-mingw32 --prefix=${MUMBLE_SNDFILE_PREFIX} --disable-shared --enable-static --with-pic
 	make
 }
 


### PR DESCRIPTION
Cygwin does not have packages for the i686-pc-mingw32 toolchain anymore,
so we might as well update.