### PR TITLE
Temporarily enable tls12 for GitHub file transfer

### DIFF
--- a/buildenv/1.3.x/win32-static/setup/earlyfetch.ps1
+++ b/buildenv/1.3.x/win32-static/setup/earlyfetch.ps1
@@ -8,6 +8,7 @@ $target = $Args[0]
 $url = $Args[1]
 $sha256hash = $Args[2]
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol.ToString() + ", tls12"
 $client = New-Object System.Net.WebClient
 $client.DownloadFile($url, $target)
 $hash = Get-FileHash $target -Algorithm SHA256


### PR DESCRIPTION
As of Feb 23, 2018 GitHub no longer supports TLS1 or TLS1.1
Windows systems which do not have TLS1.2 enabled cannot successfully establish a TLS session with GitHub. 
This causes setup.cmd to fail silently.

https://blog.github.com/2018-02-23-weak-cryptographic-standards-removed/