### PR TITLE
WIP: clang-cl support for win32-static/win64-static buildenvs

### DIFF
--- a/buildenv/1.3.x/win32-static/openssl.build
+++ b/buildenv/1.3.x/win32-static/openssl.build
@@ -36,13 +36,13 @@ function build {
 		sed -i -e 's,/MT ,/MDd ,g' ms/nt.mak
 	fi
 
-	cmd /c nmake -f ms\\nt.mak
+	cmd /c nmake -f ms\\nt.mak "CC=${MUMBLE_CC}"
 }
 
 function testsuite {
-	cmd /c nmake -f ms\\nt.mak test
+	cmd /c nmake -f ms\\nt.mak test "CC=${MUMBLE_CC}"
 }
 
 function install {
-	cmd /c nmake -f ms\\nt.mak install
+	cmd /c nmake -f ms\\nt.mak install "CC=${MUMBLE_CC}"
 }

--- a/buildenv/1.3.x/win32-static/setup.cmd
+++ b/buildenv/1.3.x/win32-static/setup.cmd
@@ -29,6 +29,9 @@ if not "%errorlevel%"=="0" (
 
 :: Get the basename of the build environment.
 if "%WANT_WIN64_BUILDENV%" == "1" (
+	if "%WANT_LLVM%" == "1" (
+		for /f %%I in ('setup\name64-llvm.cmd') do set NAME=%%I
+	)
 	if "%WANT_DEBUG_BUILDENV%" == "1" (
 		for /f %%I in ('setup\name64-debug.cmd') do set NAME=%%I
 	)

--- a/buildenv/1.3.x/win32-static/setup/name64-llvm.cmd
+++ b/buildenv/1.3.x/win32-static/setup/name64-llvm.cmd
@@ -1,0 +1,8 @@
+:: Copyright 2013-2015 The 'mumble-releng' Authors. All rights reserved.
+:: Use of this source code is governed by a BSD-style license that
+:: can be found in the LICENSE file in the source tree or at
+:: <http://mumble.info/mumble-releng/LICENSE>.
+
+@echo off
+for /f "delims=" %%i in ('git rev-list HEAD --count') do set count=%%i
+git log -n 1 --date=short --pretty="format:win64-static-llvm-1.3.x-%%ad-%%h-%count%"

--- a/buildenv/1.3.x/win32-static/setup/prep.cmd
+++ b/buildenv/1.3.x/win32-static/setup/prep.cmd
@@ -9,6 +9,7 @@ IF %MUMBLE_PREFIX:~-1%==\ SET MUMBLE_PREFIX=%MUMBLE_PREFIX:~0,-1%
 SET MUMBLE_PREFIX_BUILD=%MUMBLE_PREFIX%.build
 SET MUMBLE_RELENG_ROOT=%MUMBLE_PREFIX%\mumble-releng
 
+SET MUMBLE_CC=cl.exe
 SET MUMBLE_BUILD_CONFIGURATION=Release
 SET MUMBLE_BUILD_USE_LTCG=1
 SET VSVER=14.0
@@ -43,6 +44,15 @@ if not errorlevel 1 (
 echo %MUMBLE_PREFIX% | findstr /C:"no-ltcg" 1>nul
 if not errorlevel 1 (
 	SET MUMBLE_BUILD_USE_LTCG=0
+)
+
+:: Automatic detection of LLVM.
+:: If you want full control of these options, feel
+:: free to delete this snippet in your own build
+:: environment.
+echo %MUMBLE_PREFIX% | findstr /C:"llvm" 1>nul
+if not errorlevel 1 (
+	SET MUMBLE_BUILD_USE_LLVM=1
 )
 
 set MUMBLE_OPENSSL_PREFIX=%MUMBLE_PREFIX%\OpenSSL
@@ -207,6 +217,11 @@ GOTO FINALIZE
 
 :FINALIZE
 
+:: If we're configured to use LLVM, setup the
+:: clang-cl VSTOOLSET.
+IF %MUMBLE_BUILD_USE_LLVM%==1 SET MUMBLE_VSTOOLSET=llvm-vs2014
+IF %MUMBLE_BUILD_USE_LLVM%==1 SET MUMBLE_CC=clang-cl.exe
+
 :: Clear out various Perl environment variables
 :: that could confuse our bundled Perl.
 SET PERL_JSON_BACKEND=
@@ -225,5 +240,6 @@ SET PATH=%MUMBLE_QT_PREFIX%\bin;%PATH%
 SET PATH=%MUMBLE_OPENSSL_PREFIX%\bin;%PATH%
 SET PATH=%MUMBLE_JOM_PREFIX%\bin;%PATH%
 SET PATH=%MUMBLE_PROTOBUF_PREFIX%\bin;%PATH%
+IF %MUMBLE_BUILD_USE_LLVM%==1 SET PATH=C:\Program Files\LLVM\bin;%PATH%
 if "%ARCH%" == "x86" SET PATH=%MUMBLE_ICE_PREFIX%\bin;%PATH%
 if "%ARCH%" == "amd64" SET PATH=%MUMBLE_ICE_PREFIX%\bin\x64;%PATH%

--- a/buildenv/1.3.x/win64-static-llvm/build-all.bash
+++ b/buildenv/1.3.x/win64-static-llvm/build-all.bash
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+# Copyright 2014 The 'mumble-releng' Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that
+# can be found in the LICENSE file in the source tree or at
+# <http://mumble.info/mumble-releng/LICENSE>.
+
+echo "The win64-static-llvm build environment is maintained "
+echo "in the same directory as the win32-static build "
+echo "environment."
+echo
+echo "I will automatically change to the win32-static directory "
+echo "and call the win32-static 'build-all.bash' to initiate "
+echo "the win64-static-llvm build."
+
+cd ../win32-static
+./build-all.bash

--- a/buildenv/1.3.x/win64-static-llvm/setup.cmd
+++ b/buildenv/1.3.x/win64-static-llvm/setup.cmd
@@ -1,0 +1,21 @@
+:: Copyright 2014 The 'mumble-releng' Authors. All rights reserved.
+:: Use of this source code is governed by a BSD-style license that
+:: can be found in the LICENSE file in the source tree or at
+:: <http://mumble.info/mumble-releng/LICENSE>.
+
+:: setup.cmd sets up a new Mumble build environment
+:: in the user's home directory (%USERPROFILE%).
+::
+:: Since the win32-static and win64-static build
+:: environments are maintained in a single directory,
+:: this setup script simply sets a flag signalling
+:: that we want a 64-bit build environment, and calls
+:: win32-static's setup.cmd.
+
+@echo off
+
+set WANT_WIN64_BUILDENV=1
+set WANT_LLVM=1
+set SETUP_DIR=%~dp0
+cd %SETUP_DIR%\..\win32-static
+setup.cmd %*


### PR DESCRIPTION
This is an experimental PR for adding clang-cl support to the Windows build.

Mostly, it's a matter of:
 - For Makefile-based builds, to abstract away the calls to cl.exe and perhaps link.exe to a variable ($MUMBLE_CC, maybe), to be able to target the LLVM binaries
 - For CMake-based builds, we probably need to change recipes to use the vcproj generator, and use the -T parameter to select the platform toolset (LLVM-vs2014). The chnage to the vcproj generator might break our ability to "install" our builds, like we currently do with `nmake install`, but I am not sure.
 - For MSBuild-based builds, we should just need to pass the correct toolset, which happens already.
 - For everything else, a combination of the above

Other things to work out:
 - Our Windows buildenvs use static libraries all the way through. From a cursory glance at the OpenSSL build, no $TOOLSET.pdb files (i.e., v120.pdb -- object PDB files) were generated during the build. Perhaps clang-cl doesn't support that at the moment, or maybe it embeds it into the .objs. Who knows. It would be best if it just emitted $TOOLSET.pdbs, so we didn't have to special case anything...